### PR TITLE
Hide useless services div

### DIFF
--- a/layouts/partials/custom/meta.html
+++ b/layouts/partials/custom/meta.html
@@ -30,4 +30,9 @@
         align-items: center;
         justify-content: space-between;
     }
+    
+    div#qfieldcloud {
+        display: none;
+    }
+
 </style>


### PR DESCRIPTION
Hide the services block since it is useless for us
from 
<img width="774" height="469" alt="image" src="https://github.com/user-attachments/assets/1b131f57-781a-471f-8470-7f65ea404428" />

to 
<img width="774" height="469" alt="Screenshot From 2025-08-22 20-10-56" src="https://github.com/user-attachments/assets/ac74e994-a2fc-4644-a62e-de84d85cf384" />
