### PR TITLE
fix(status): Base URL should be status.qfield.cloud

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -97,7 +97,7 @@ defaultContentLanguage: en
 #
 # Broken example:
 # baseUrl: /
-baseURL: https://status.qfield.org
+baseURL: https://status.qfield.cloud
 
 # For features like Last modified, you
 # need to use a Git repository. If you

--- a/static/CNAME
+++ b/static/CNAME
@@ -1,1 +1,1 @@
-status.qfield.org
+status.qfield.cloud


### PR DESCRIPTION
We change the main URL from status.qfield.org to status.qfield.cloud This is mainly due to Exoscale being unable to do a URL forward properly (see https://portal.exoscale.com/u/qfieldcloud-gmbh/tickets/1132452). We will then add a URL forwarding from .org to .cloud with Dreamhost.